### PR TITLE
fix write: merge! header instead of push!

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # User visible changes for EasyFITS
 
+## Version 0.5.3
+
+- Fix writing in a file with a given header and image array. Header is now merged with success.
+
 ## Version 0.5.2
 
 - Call `write(file::FitsFile,FitsImageHDU{T},dims...)` to create a new FITS image HDU

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EasyFITS"
 uuid = "a977f4a2-36a7-4172-89e7-19c2726f82e5"
 authors = ["Éric Thiébaut <https://github.com/emmt>"]
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 CFITSIO_jll = "b3e40c51-02ae-5482-8a39-3ace5868dcf4"

--- a/src/images.jl
+++ b/src/images.jl
@@ -360,7 +360,7 @@ end
 function Base.write(file::FitsFile, hdr::Union{Header,Nothing},
                     arr::AbstractArray{T,N}) where {T<:Number,N}
     # FIXME: improve type-stability
-    write(push!(write(file, FitsImageHDU, T, size(arr)), hdr), arr)
+    write(merge!(write(file, FitsImageHDU, T, size(arr)), hdr), arr)
     return file
 end
 


### PR DESCRIPTION
the header is a structure of cards.
when file is created by the first write it already has an initial structure of cards.
the two structures must be merged. push! cannot work.