### PR TITLE
Fix write fitstablehdu

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # User visible changes for EasyFITS
 
+## Version 0.5.12 (not bumped yet)
+
+- For FITS tables, cell dimensions are mandatory for columns whose cell type is `String`. The user
+must now provide the maximum number of characters for the strings. It avoids ambiguities. When the
+user define a column with cell type `Int` and no dimension, the cell is assumed scalar. But a
+`String` is non-scalar by definition. Previous code, when no dimension provided, was setting
+maximum string length to `1`, which is certainly not what the user meant.
+- In the same topic as the previous bullet: trying to add a string that is too long for the cell
+maximum now throws an error, instead of truncating. It avoids writing wrong data in the file.
+
 ## Version 0.5.11
 
 - Extend `haskey` for `FitsHDU` instances.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,13 +2,14 @@
 
 ## Version 0.5.12 (not bumped yet)
 
-- For FITS tables, cell dimensions are mandatory for columns whose cell type is `String`. The user
-must now provide the maximum number of characters for the strings. It avoids ambiguities. When the
-user define a column with cell type `Int` and no dimension, the cell is assumed scalar. But a
-`String` is non-scalar by definition. Previous code, when no dimension provided, was setting
-maximum string length to `1`, which is certainly not what the user meant.
-- In the same topic as the previous bullet: trying to add a string that is too long for the cell
-maximum now throws an error, instead of truncating. It avoids writing wrong data in the file.
+- Columns of strings in FITS tables:
+  - An error is raised when attempting to write strings longer than the maximal length in a column
+    of strings. The previous behavior was to truncate the strings and display a warning.
+  - When cell dimensions are not specified in a column definition, it is assumed that a single
+    value is stored by each cell of that column. This is inappropriate for strings for which the
+    default amounts to storing a single character per cell. Cell dimensions are therefore now
+    mandatory for defining columns of strings in a table HDU. Note that this is the simplest
+    way to specify the maximum length of the strings.
 
 ## Version 0.5.11
 

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -902,7 +902,7 @@ table may be created in a single call:
 """
 function write(file::FitsFile, ::Type{FitsTableHDU},
                cols::Pair{<:ColumnName,<:Any}...; kwds...)
-    return write(file, FITSTableHDU, cols; kwds...)
+    return write(file, FitsTableHDU, cols; kwds...)
 end
 
 function write(file::FitsFile, ::Type{FitsTableHDU},
@@ -1019,7 +1019,7 @@ function write(hdu::FitsTableHDU,
     if units !== nothing
         card = get(hdu, "TUNIT$num", nothing)
         (card === nothing ? isempty(units) :
-            cart.type == FITS_STRING && units == card.string) || bad_argument("invalid column units")
+            card.type == FITS_STRING && units == card.string) || bad_argument("invalid column units")
     end
 
     # Check string case.

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -479,7 +479,8 @@ function convert_eltype(::Type{UInt8}, A::AbstractArray{<:AbstractString,N};
         end
         off += firstdim
     end
-    firstdim ≥ maxlen || @warn "strings have been truncated to $firstdim characters, whereas $maxlen are needed"
+    firstdim ≥ maxlen || throw(ArgumentError(
+        "Cannot add a string of $maxlen bytes, the column maximum is set to $firstdim"))
     nbads == 0 || @warn "$nbads non-ASCII or null characters have been filtered"
     return B
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -174,6 +174,17 @@ FITS table extension.
 """
 const ColumnDims = Union{Integer,Tuple{Vararg{Integer}}}
 
+
+"""
+    EasyFITS.DimensionlessColumnDefinition
+
+is similar to [`ColumnDefinition`](@ref) but without cell dimensions.
+
+"""
+const DimensionlessColumnDefinition = Union{ColumnEltype,
+                                            Tuple{ColumnEltype},
+                                            Tuple{ColumnEltype,ColumnUnits}}
+
 """
     EasyFITS.ColumnDefinition
 
@@ -181,12 +192,10 @@ is the possible type(s) for specifying the type of values, cell dimensions, and
 units of a column of a FITS table extension.
 
 """
-const ColumnDefinition = Union{ColumnEltype,
-                               Tuple{ColumnEltype},
-                               Tuple{ColumnEltype,ColumnDims},
+const ColumnDefinition = Union{Tuple{ColumnEltype,ColumnDims},
                                Tuple{ColumnEltype,ColumnDims,ColumnUnits},
-                               Tuple{ColumnEltype,ColumnUnits},
-                               Tuple{ColumnEltype,ColumnUnits,ColumnDims}}
+                               Tuple{ColumnEltype,ColumnUnits,ColumnDims},
+                               DimensionlessColumnDefinition}
 
 # Union of possible types for specifying column data to write.
 """

--- a/src/types.jl
+++ b/src/types.jl
@@ -192,10 +192,10 @@ is the possible type(s) for specifying the type of values, cell dimensions, and
 units of a column of a FITS table extension.
 
 """
-const ColumnDefinition = Union{Tuple{ColumnEltype,ColumnDims},
+const ColumnDefinition = Union{DimensionlessColumnDefinition,
+                               Tuple{ColumnEltype,ColumnDims},
                                Tuple{ColumnEltype,ColumnDims,ColumnUnits},
-                               Tuple{ColumnEltype,ColumnUnits,ColumnDims},
-                               DimensionlessColumnDefinition}
+                               Tuple{ColumnEltype,ColumnUnits,ColumnDims}}
 
 # Union of possible types for specifying column data to write.
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -678,6 +678,12 @@ end
     @test x3["NAME"] == name
     @test x3["XY"] == xy
     @test x3["LABEL"] == label
+
+    # write (version with columns given as varargs)
+    fitsfile = openfits(tempfile, "w!")
+    @test write(fitsfile, FitsHeader(), [1;;])[1] isa FitsImageHDU
+    @test write(fitsfile, FitsTableHDU, :col1 => Float32) isa FitsTableHDU
+    @test write(fitsfile, FitsTableHDU, :col1 => Float32, :col2 => Int) isa FitsTableHDU
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -680,10 +680,35 @@ end
     @test x3["LABEL"] == label
 
     # write (version with columns given as varargs)
-    fitsfile = openfits(tempfile, "w!")
-    @test write(fitsfile, FitsHeader(), [1;;])[1] isa FitsImageHDU
-    @test write(fitsfile, FitsTableHDU, :col1 => Float32) isa FitsTableHDU
-    @test write(fitsfile, FitsTableHDU, :col1 => Float32, :col2 => Int) isa FitsTableHDU
+    openfits(tempfile, "w!") do fitsfile
+        write(fitsfile, FitsHeader(), [1;;])
+        @test write(fitsfile, FitsTableHDU, :col1 => Float32) isa FitsTableHDU
+        @test write(fitsfile, FitsTableHDU, :col1 => Float32, :col2 => Int) isa FitsTableHDU
+    end
+
+    # String columns, check dimensions and write
+    openfits(tempfile, "w!") do fitsfile
+        write(fitsfile, FitsHeader(), [1;;])
+
+        # 10-char strings
+        let hdu
+            @test (hdu = write(fitsfile, FitsTableHDU, :col1 => (String, 10))) isa FitsTableHDU
+            data = ["abcdefghij", "abcd", "abcdefghi"]
+            @test write(hdu, :col1 => data) isa FitsTableHDU
+            @test read(hdu, :col1) == data
+        end
+
+        # pairs of 4-char strings
+        let hdu
+            @test (hdu = write(fitsfile, FitsTableHDU, :col1 => (String, (4,2)))) isa FitsTableHDU
+            data = ["abcd" ; "defg" ;; "hijk" ; "lmno" ;; "pq" ; "rstu"]
+            @test write(hdu, :col1 => data) isa FitsTableHDU
+            @test read(hdu, :col1) == data
+        end
+
+        # dimension is mandatory
+        @test_throws ArgumentError write(fitsfile, FitsTableHDU, :col1 => String)
+    end
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -708,6 +708,12 @@ end
 
         # dimension is mandatory
         @test_throws ArgumentError write(fitsfile, FitsTableHDU, :col1 => String)
+
+        # overlarge String is a failure
+        let hdu
+            hdu = write(fitsfile, FitsTableHDU, :col1 => (String, 3))
+            @test_throws ArgumentError write(hdu, :col1 => ["abcd"])
+        end
     end
 end
 


### PR DESCRIPTION
## commit 41dcc4e3e2870ab38b7ff37d83d574bcd9263f1d

- fix typo `FITSTableHDU` instead of `FitsTableHDU`
- fix typo `cart` instead of `card`
- add the tests that were triggering the typos

## commit 873f682d34a74ef1029dc675b2529cbf47822d46

- split the type ColumnDefinition in two: one with dims and one without
- throw an error when a table column is defined with type String and no dimensions
- add tests for columns String with and without dimensions

## commit e50a9435df1134ac5fbf4c33d86863d1140b9a83

- when an overlage string is added to a table column, instead of truncating and warning, now it throws an error
- add tests to check error presence

