### PR TITLE
zero dims gives zero length for img to write

### DIFF
--- a/src/images.jl
+++ b/src/images.jl
@@ -402,7 +402,7 @@ function write(hdu::FitsImageHDU{<:Any,N},
                null::Union{Number,Nothing} = nothing) where {T<:Number,L,N}
     type = pixeltype_to_code(arr) # clash if unsupported pixel type
     dims = get_img_size(hdu)
-    len = length(arr)
+    len = iszero(ndims(arr)) ? 0 : length(arr)
     if first isa Tuple && last isa Tuple && null isa Nothing
         # Write a rectangular sub-image. NOTE: First and last pxiels must both
         # be specified because it is not possible to guess one given the other


### PR DESCRIPTION
The following code fails:

```julia
writefits!("/tmp/toto.fits", FitsHeader(), fill(1e0))
ERROR: FitsError(302): "column number < 1 or > tfields"
Stacktrace:
  [1] check
    @ ~/Documents/EasyFITS.jl-antoine/src/utils.jl:34 [inlined]
  [2] #write#75
    @ ~/Documents/EasyFITS.jl-antoine/src/images.jl:444 [inlined]
  [3] write
    @ ~/Documents/EasyFITS.jl-antoine/src/images.jl:398 [inlined]
  [4] write(file::FitsFile, hdr::FitsHeader, arr::Array{Float64, 0})
    @ EasyFITS ~/Documents/EasyFITS.jl-antoine/src/images.jl:365
  [5] #41
    @ ~/Documents/EasyFITS.jl-antoine/src/files.jl:190 [inlined]
  [6] FitsFile(func::EasyFITS.var"#41#42"{Tuple{FitsHeader, Array{Float64, 0}}}, filename::String, mode::String; kwds::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ EasyFITS ~/Documents/EasyFITS.jl-antoine/src/files.jl:40
  [7] FitsFile(func::Function, filename::String, mode::String)
    @ EasyFITS ~/Documents/EasyFITS.jl-antoine/src/files.jl:36
  [8] #openfits#23
    @ ~/Documents/EasyFITS.jl-antoine/src/files.jl:57 [inlined]
  [9] openfits
    @ ~/Documents/EasyFITS.jl-antoine/src/files.jl:55 [inlined]
 [10] writefits(::String, ::FitsHeader, ::Vararg{Any}; overwrite::Bool, kwds::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ EasyFITS ~/Documents/EasyFITS.jl-antoine/src/files.jl:189
 [11] writefits!(::String, ::FitsHeader, ::Vararg{Any}; kwds::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ EasyFITS ~/Documents/EasyFITS.jl-antoine/src/files.jl:226
 [12] writefits!(::String, ::FitsHeader, ::Vararg{Any})
    @ EasyFITS ~/Documents/EasyFITS.jl-antoine/src/files.jl:225
 [13] top-level scope
    @ REPL[3]:1
 [14] top-level scope
    @ ~/julia-1.9.4/share/julia/stdlib/v1.9/REPL/src/REPL.jl:1416
```

The problem is that in Julia, the length of a zero dimensional array is one. In the `write()` function, we want `len` to be the number of scalar value to write, so it should be zero when the array is zero dimensional.

In Julia, a zero dimensional array contains a value, whereas in FITS standard it means no data at all.

I suggest to favorise FITS meaning, that is a zero dimensional array has no data, and to disregard the value contained in the Julia zero dimensional array. This suggestion relies on the fact that this is for now, the only way of writing a zero dimensional fits file in EasyFITS (apart from it being bugged)